### PR TITLE
Issue #95 - convert to manifest v3

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -14,6 +14,7 @@
     "after": true,
     "before": true,
     "window": true,
+    "self": true,
     "require": true,
     "module": true,
     "__dirname": true,

--- a/src/agent-block.json
+++ b/src/agent-block.json
@@ -1,0 +1,22 @@
+[
+  {
+    "id" : 1,
+    "priority": 1,
+    "action" : { 
+      "type" : "modifyHeaders",
+      "requestHeaders": [
+          { 
+            "header": "user-agent", 
+            "operation": "remove"
+          }
+        ] 
+    },
+    "condition" : {
+      "urlFilter" : "*",
+      "resourceTypes": [
+        "main_frame",
+        "sub_frame"
+      ]
+    }
+  }
+]

--- a/src/js/back.js
+++ b/src/js/back.js
@@ -19,13 +19,13 @@
 "use strict";
 
 const browser = require("webextension-polyfill");
-window.browser = browser;
+self.browser = browser;
 const {additionalPermission, addRequestListener, removeRequestListener,
       updateRequestObj, addBlockAgentListener, removeBlockAgentListener,
       deleteCookies} = require("./common");
 const {browsingData} = require("./data");
 
-window.collectedRequests = [];
+self.collectedRequests = [];
 const requestCollectionLength = 500;
 
 async function profileStart()
@@ -89,12 +89,6 @@ function deleteBrowsingData(data)
     browser.browsingData.remove({}, browsingDataObj);
   }
 }
-
-window.deleteBrowsingData = async() =>
-{
-  const {settingList} = await browser.storage.local.get("settingList");
-  deleteBrowsingData(settingList);
-};
 
 function startCollectingRequests()
 {

--- a/src/js/common.js
+++ b/src/js/common.js
@@ -54,21 +54,16 @@ function updateRequestObj(details, actionType)
  ******************************************************************************/
 function addBlockAgentListener()
 {
-  onBeforeSendHeaders.addListener(blockUserAgent,
-                                  {urls: ["<all_urls>"]},
-                                  ["blocking", "requestHeaders"]);
+  browser.declarativeNetRequest.updateEnabledRulesets({
+    enableRulesetIds: ["block-agent"]
+  });
 }
 
 function removeBlockAgentListener()
 {
-  onBeforeSendHeaders.removeListener(blockUserAgent);
-}
-
-function blockUserAgent(details)
-{
-  const filterUserAgent = (request) => request.name != "User-Agent";
-  const requestHeaders = details.requestHeaders.filter(filterUserAgent);
-  return {requestHeaders};
+  browser.declarativeNetRequest.updateEnabledRulesets({
+    disableRulesetIds: ["block-agent"]
+  });
 }
 
 function removeStartDot(string)

--- a/src/js/ui/tabs/network.js
+++ b/src/js/ui/tabs/network.js
@@ -30,7 +30,6 @@ const collectHeadersId = "collectHeaders";
 const permissionNotificationMsgId = "additionalPermissions_notification";
 const filterParams = ["statusLine", "statusCode", "type", "url", "method"];
 
-let collectedRequests = [];
 let tableList = null;
 
 document.addEventListener("DOMContentLoaded" , async function()
@@ -183,7 +182,7 @@ async function onRequestsWidgetAction(action, element)
     }
     case "download-all": {
       const downloadJson = [];
-      for (const {request, data} of collectedRequests)
+      for (const {request, data} of tableList.items)
       {
         const requestObj = {};
         requestObj["action"] = data.type;

--- a/src/js/ui/tabs/network.js
+++ b/src/js/ui/tabs/network.js
@@ -59,10 +59,10 @@ document.addEventListener("DOMContentLoaded" , async function()
 
   registerActionListener($("#requestsWidget"), onRequestsWidgetAction);
   tableList.setListener(onRequestsWidgetActionComp);
-  const window = await browser.runtime.getBackgroundPage();
-
-  collectedRequests = window.collectedRequests;
-  tableList.addItems(collectedRequests);
+  browser.runtime.sendMessage({message: "getCollectedRequests"}).then((requests) =>
+  {
+    tableList.addItems(requests);
+  });
 },false);
 
 async function onNetworkSettingChange(settingName, isActive, permissionChange)
@@ -177,8 +177,7 @@ async function onRequestsWidgetAction(action, element)
   switch (action)
   {
     case "delete-all": {
-      const window = await browser.runtime.getBackgroundPage();
-      window.collectedRequests = [];
+      await browser.runtime.sendMessage({message: "deleteCollectedNetworkRequests"});
       tableList.empty();
       break;
     }

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,13 +1,12 @@
 {
-   "manifest_version": 2,
+   "manifest_version": 3,
    "default_locale": "en_US",
    "name": "__MSG_chrome_extension_name__",
    "description": "__MSG_chrome_extension_description__",
    "background": {
-      "scripts": ["js/back.js"],
-      "persistence": false
+      "service_worker": "js/back.js"
    },
-   "browser_action": {
+   "action": {
       "default_icon": "img/logo.png",
       "default_popup": "popup.html"
    },
@@ -16,7 +15,7 @@
       "16": "img/logo-16x16.png",
       "48": "img/logo-48x48.png"
    },
-   "optional_permissions": ["<all_urls>"],
+   "optional_host_permissions": ["<all_urls>"],
    "permissions": ["privacy", "cookies", "browsingData", "tabs", "webRequest", "webRequestBlocking", "storage"],
    "incognito": "split",
    "update_url": "https://clients2.google.com/service/update2/crx"

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -15,8 +15,15 @@
       "16": "img/logo-16x16.png",
       "48": "img/logo-48x48.png"
    },
+   "declarative_net_request" : {
+      "rule_resources": [{
+         "id" : "block-agent",
+         "enabled": false,
+         "path": "agent-block.json"
+      }]
+   },
    "optional_host_permissions": ["<all_urls>"],
-   "permissions": ["privacy", "cookies", "browsingData", "tabs", "webRequest", "webRequestBlocking", "storage"],
+   "permissions": ["privacy", "cookies", "browsingData", "tabs", "webRequest", "declarativeNetRequestWithHostAccess", "storage"],
    "incognito": "split",
    "update_url": "https://clients2.google.com/service/update2/crx"
 }

--- a/test/common.js
+++ b/test/common.js
@@ -30,9 +30,12 @@ async function openPopupPage()
       `--load-extension=${extensionPath}`
     ]
   });
+  // The extension target is not ready at this point, so we wait a bit.
+  await sleep(1000);
+
   const targets = await browser.targets();
   const extensionTarget = targets.find((target) =>
-    target.url().startsWith("chrome-extension://") && target.type() === "background_page"
+    target.url().startsWith("chrome-extension://") && target.type() === "service_worker"
   );
   const extensionUrl = extensionTarget.url() || '';
   const [,, extensionID] = extensionUrl.split('/');
@@ -43,6 +46,11 @@ async function openPopupPage()
     waitUntil: "networkidle0"
   });
   return page;
+}
+
+function sleep(ms)
+{
+  return new Promise(resolve => setTimeout(resolve, ms));
 }
 
 async function closeBrowser()

--- a/test/manifest.js
+++ b/test/manifest.js
@@ -29,13 +29,13 @@ const manifestFile = "dist/manifest.json";
 const allOrigins = "<all_urls>";
 
 /**
- * Move "<all_urls>" from optional_permissions to permissions
+ * Move "<all_urls>" from optional_host_permissions to host_permissions
  */
 async function allUrlsToPermissions()
 {
   const manifest = await getManifestFile();
-  manifest.permissions.push(manifest.optional_permissions[0]);
-  delete manifest.optional_permissions;
+  manifest.host_permissions = manifest.optional_host_permissions;
+  delete manifest.optional_host_permissions;
   await writeFile(manifestFile, JSON.stringify(manifest, null, 2), "utf8");
 }
 
@@ -45,8 +45,8 @@ async function allUrlsToPermissions()
 async function restorePermissions()
 {
   const manifest = await getManifestFile();
-  manifest.optional_permissions = [allOrigins];
-  manifest.permissions = manifest.permissions.filter(e => e !== allOrigins);
+  manifest.optional_host_permissions = [allOrigins];
+  delete manifest.host_permissions;
   await writeFile(manifestFile, JSON.stringify(manifest, null, 2), "utf8");
 }
 

--- a/test/puppeteer/network.js
+++ b/test/puppeteer/network.js
@@ -144,7 +144,7 @@ describe("Testing Network tab", () =>
     await clickToggle(handle);
     await page.waitForTimeout(10);
     await page2.goto("http://127.0.0.1:4000/");
-    await page.waitForTimeout(50);
+    await page.waitForTimeout(100);
     equal((await getItemText("pm-table-item1", null, "type")), "main_frame");
     equal((await getItemText("pm-table-item1", null, "url")), "http://127.0.0.1:4000/");
     equal((await getItemData("pm-table-item1", null, "type")), "send");

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -44,6 +44,7 @@ module.exports =
         transform: (content) => argv.prod ? csso.minify(content).css : content},
       { from: './src/img', to: "img" },
       { from: "./src/popup.html", to: "popup.html" },
+      { from: "./src/agent-block.json", to: "agent-block.json" },
       { from: "./src/manifest.json", to: "manifest.json",
         transform: manifest.transform }
     ]})


### PR DESCRIPTION
## Background

In order to keep Privacy Manager functioning, it needs to be converted to [Manifest V3](https://developer.chrome.com/docs/extensions/mv3/intro/).

## Migration guide

https://developer.chrome.com/docs/extensions/mv3/intro/mv3-migration/

## What is included
- [x] - Use [Declarative net request API](https://developer.chrome.com/docs/extensions/reference/declarativeNetRequest/) over WebRequest API.
- Changes to Manifest.json
  - [x] - `browser_action` -> `action`
  - [x] - `optional_permissions` -> `optional_host_permissions`
  - [x] -  update `manifest_version` to v3
  - [x] -  use service_worker
  - [x] - Replace webRequestBlocking with Declarative net request API
- [x] - Do not use DOM API in Service Worker.
- [x] - Store network request using storage API.
- [x] - Ensure network tab collected data persist after SW is killed.